### PR TITLE
Allow skipped test declarations to exceed max length

### DIFF
--- a/test.js
+++ b/test.js
@@ -21,7 +21,7 @@ module.exports = {
 		// Allow test declarations to exceed max line length.
 		"max-len": ["error", {
 			code: 100,
-			ignorePattern: "^\\s*(?:it|specify|describe|context)(?:\.skip)?\\(",
+			ignorePattern: "^\\s*(?:it|specify|describe|context)(?:\\.skip)?\\(",
 		}],
 
 		// Prevent `only` from being left on a test or test group.

--- a/test.js
+++ b/test.js
@@ -21,7 +21,7 @@ module.exports = {
 		// Allow test declarations to exceed max line length.
 		"max-len": ["error", {
 			code: 100,
-			ignorePattern: "^\\s*(?:it|specify|describe|context)\\(",
+			ignorePattern: "^\\s*(?:it|specify|describe|context)(?:\.skip)?\\(",
 		}],
 
 		// Prevent `only` from being left on a test or test group.


### PR DESCRIPTION
Shouldn't affect anybody but this is something I've been meaning to do for a while. If we have the max line length exception for test declarations in mocha, it should also match skipped ones for the times when we need to commit and merge them. I'm just now running into a situation where I'd like to do so. :+1: 