### PR TITLE
Allow == when comparing to null

### DIFF
--- a/base.js
+++ b/base.js
@@ -99,7 +99,7 @@ module.exports = {
 		"dot-location": ["error", "property"],
 		"dot-notation": "error",
 		"eol-last": "error",
-		"eqeqeq": "error",
+		"eqeqeq": ["error", "always", {null: "ignore"}],
 		"func-call-spacing": "off", // Replaced in typescript-eslint
 		"func-names": "off",
 		"function-paren-newline": ["error", "multiline-arguments"],


### PR DESCRIPTION
Wanting to relax this rule, as type coercion for null is sane. It allows you to check both null and undefined at once with `a == null` instead of have to do `a === null || a === undefined ` or use something like lodash isNil.