### PR TITLE
Fix: update dependencies remove confusing duplicate export rule

### DIFF
--- a/oxlint/.oxlintrc.json
+++ b/oxlint/.oxlintrc.json
@@ -121,12 +121,7 @@
 			}
 		],
 		"no-div-regex": "error",
-		"no-duplicate-imports": [
-			"error",
-			{
-				"includeExports": true
-			}
-		],
+		"no-duplicate-imports": ["error"],
 		"no-else-return": [
 			"error",
 			{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@batterii/eslint-config-vurvey",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@batterii/eslint-config-vurvey",
-			"version": "1.1.4",
+			"version": "1.1.5",
 			"license": "MIT",
 			"dependencies": {
 				"@eslint/js": "^9.39.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
 			},
 			"peerDependencies": {
 				"eslint": "^9.7",
-				"oxlint": "^1.57.0",
-				"oxlint-tsgolint": "^0.17.3"
+				"oxlint": "^1.63.0",
+				"oxlint-tsgolint": "^0.22.1"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -226,10 +226,52 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
+		"node_modules/@oxlint-tsgolint/darwin-arm64": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.22.1.tgz",
+			"integrity": "sha512-4150Lpgc1YM09GcjA6GSrra1JoPjC7aOpfywLjWEY4vW0Sd1qKzqHF1WRaiw0/qUZ40OATYdv3aRd7ipPkWQbw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true
+		},
+		"node_modules/@oxlint-tsgolint/darwin-x64": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.22.1.tgz",
+			"integrity": "sha512-vFWcPWYOgZs4HWcgS1EjUZg33NLcNfEYU49KGImmCfZWkflENrmBYV4HN/C0YeAPum6ZZ/goPSvQrB/cOD+NfA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true
+		},
+		"node_modules/@oxlint-tsgolint/linux-arm64": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.22.1.tgz",
+			"integrity": "sha512-6LiUpP0Zir3+29FvBm7Y28q/dBjSHqTZ5MhG1Ckw4fGhI4cAvbcwXaKvbjx1TP7rRmBNOoq/M5xdpHjTb+GAew==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true
+		},
 		"node_modules/@oxlint-tsgolint/linux-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.17.3.tgz",
-			"integrity": "sha512-/kW5oXtBThu4FjmgIBthdmMjWLzT3M1TEDQhxDu7hQU5xDeTd60CDXb2SSwKCbue9xu7MbiFoJu83LN0Z/d38g==",
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.22.1.tgz",
+			"integrity": "sha512-fuX1hEQfpHauUbXADsfqVhRzrUrGabzGXbj5wsp2vKhV5uk/Rze8Mba9GdjFGECzvXudMGqHqxB4r6jGRdhxVA==",
 			"cpu": [
 				"x64"
 			],
@@ -240,10 +282,259 @@
 			],
 			"peer": true
 		},
+		"node_modules/@oxlint-tsgolint/win32-arm64": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.22.1.tgz",
+			"integrity": "sha512-8SZidAj+jrbZf9ZjBEYW0tiNZ+KasqB2zgW26qdiPpQSF/DzURnPmXz651IeA9YsmbVdHGIooEHUmev6QJdquA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true
+		},
+		"node_modules/@oxlint-tsgolint/win32-x64": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.22.1.tgz",
+			"integrity": "sha512-QweSk9H5lFh5Y+WUf2Kq/OAN88V6+62ZwGhP38gqdRotI90luXSMkruFTj7Q2rYrzH4ZVNaSqx7NY8JpSfIzqg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true
+		},
+		"node_modules/@oxlint/binding-android-arm-eabi": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.63.0.tgz",
+			"integrity": "sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-android-arm64": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.63.0.tgz",
+			"integrity": "sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-darwin-arm64": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.63.0.tgz",
+			"integrity": "sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-darwin-x64": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.63.0.tgz",
+			"integrity": "sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-freebsd-x64": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.63.0.tgz",
+			"integrity": "sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.63.0.tgz",
+			"integrity": "sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-arm-musleabihf": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.63.0.tgz",
+			"integrity": "sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-arm64-gnu": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.63.0.tgz",
+			"integrity": "sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-arm64-musl": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.63.0.tgz",
+			"integrity": "sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-ppc64-gnu": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.63.0.tgz",
+			"integrity": "sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-riscv64-gnu": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.63.0.tgz",
+			"integrity": "sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-riscv64-musl": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.63.0.tgz",
+			"integrity": "sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-s390x-gnu": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.63.0.tgz",
+			"integrity": "sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
 		"node_modules/@oxlint/binding-linux-x64-gnu": {
-			"version": "1.57.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.57.0.tgz",
-			"integrity": "sha512-AghS18w+XcENcAX0+BQGLiqjpqpaxKJa4cWWP0OWNLacs27vHBxu7TYkv9LUSGe5w8lOJHeMxcYfZNOAPqw2bg==",
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.63.0.tgz",
+			"integrity": "sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA==",
 			"cpu": [
 				"x64"
 			],
@@ -251,6 +542,91 @@
 			"optional": true,
 			"os": [
 				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-linux-x64-musl": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.63.0.tgz",
+			"integrity": "sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-openharmony-arm64": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.63.0.tgz",
+			"integrity": "sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-win32-arm64-msvc": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.63.0.tgz",
+			"integrity": "sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-win32-ia32-msvc": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.63.0.tgz",
+			"integrity": "sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxlint/binding-win32-x64-msvc": {
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.63.0.tgz",
+			"integrity": "sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
 			],
 			"peer": true,
 			"engines": {
@@ -1247,9 +1623,9 @@
 			}
 		},
 		"node_modules/oxlint": {
-			"version": "1.57.0",
-			"resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.57.0.tgz",
-			"integrity": "sha512-DGFsuBX5MFZX9yiDdtKjTrYPq45CZ8Fft6qCltJITYZxfwYjVdGf/6wycGYTACloauwIPxUnYhBVeZbHvleGhw==",
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.63.0.tgz",
+			"integrity": "sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg==",
 			"license": "MIT",
 			"peer": true,
 			"bin": {
@@ -1262,28 +1638,28 @@
 				"url": "https://github.com/sponsors/Boshen"
 			},
 			"optionalDependencies": {
-				"@oxlint/binding-android-arm-eabi": "1.57.0",
-				"@oxlint/binding-android-arm64": "1.57.0",
-				"@oxlint/binding-darwin-arm64": "1.57.0",
-				"@oxlint/binding-darwin-x64": "1.57.0",
-				"@oxlint/binding-freebsd-x64": "1.57.0",
-				"@oxlint/binding-linux-arm-gnueabihf": "1.57.0",
-				"@oxlint/binding-linux-arm-musleabihf": "1.57.0",
-				"@oxlint/binding-linux-arm64-gnu": "1.57.0",
-				"@oxlint/binding-linux-arm64-musl": "1.57.0",
-				"@oxlint/binding-linux-ppc64-gnu": "1.57.0",
-				"@oxlint/binding-linux-riscv64-gnu": "1.57.0",
-				"@oxlint/binding-linux-riscv64-musl": "1.57.0",
-				"@oxlint/binding-linux-s390x-gnu": "1.57.0",
-				"@oxlint/binding-linux-x64-gnu": "1.57.0",
-				"@oxlint/binding-linux-x64-musl": "1.57.0",
-				"@oxlint/binding-openharmony-arm64": "1.57.0",
-				"@oxlint/binding-win32-arm64-msvc": "1.57.0",
-				"@oxlint/binding-win32-ia32-msvc": "1.57.0",
-				"@oxlint/binding-win32-x64-msvc": "1.57.0"
+				"@oxlint/binding-android-arm-eabi": "1.63.0",
+				"@oxlint/binding-android-arm64": "1.63.0",
+				"@oxlint/binding-darwin-arm64": "1.63.0",
+				"@oxlint/binding-darwin-x64": "1.63.0",
+				"@oxlint/binding-freebsd-x64": "1.63.0",
+				"@oxlint/binding-linux-arm-gnueabihf": "1.63.0",
+				"@oxlint/binding-linux-arm-musleabihf": "1.63.0",
+				"@oxlint/binding-linux-arm64-gnu": "1.63.0",
+				"@oxlint/binding-linux-arm64-musl": "1.63.0",
+				"@oxlint/binding-linux-ppc64-gnu": "1.63.0",
+				"@oxlint/binding-linux-riscv64-gnu": "1.63.0",
+				"@oxlint/binding-linux-riscv64-musl": "1.63.0",
+				"@oxlint/binding-linux-s390x-gnu": "1.63.0",
+				"@oxlint/binding-linux-x64-gnu": "1.63.0",
+				"@oxlint/binding-linux-x64-musl": "1.63.0",
+				"@oxlint/binding-openharmony-arm64": "1.63.0",
+				"@oxlint/binding-win32-arm64-msvc": "1.63.0",
+				"@oxlint/binding-win32-ia32-msvc": "1.63.0",
+				"@oxlint/binding-win32-x64-msvc": "1.63.0"
 			},
 			"peerDependencies": {
-				"oxlint-tsgolint": ">=0.15.0"
+				"oxlint-tsgolint": ">=0.22.1"
 			},
 			"peerDependenciesMeta": {
 				"oxlint-tsgolint": {
@@ -1292,21 +1668,21 @@
 			}
 		},
 		"node_modules/oxlint-tsgolint": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.17.3.tgz",
-			"integrity": "sha512-1eh4bcpOMw0e7+YYVxmhFc2mo/V6hJ2+zfukqf+GprvVn3y94b69M/xNrYLmx5A+VdYe0i/bJ2xOs6Hp/jRmRA==",
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.22.1.tgz",
+			"integrity": "sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg==",
 			"license": "MIT",
 			"peer": true,
 			"bin": {
 				"tsgolint": "bin/tsgolint.js"
 			},
 			"optionalDependencies": {
-				"@oxlint-tsgolint/darwin-arm64": "0.17.3",
-				"@oxlint-tsgolint/darwin-x64": "0.17.3",
-				"@oxlint-tsgolint/linux-arm64": "0.17.3",
-				"@oxlint-tsgolint/linux-x64": "0.17.3",
-				"@oxlint-tsgolint/win32-arm64": "0.17.3",
-				"@oxlint-tsgolint/win32-x64": "0.17.3"
+				"@oxlint-tsgolint/darwin-arm64": "0.22.1",
+				"@oxlint-tsgolint/darwin-x64": "0.22.1",
+				"@oxlint-tsgolint/linux-arm64": "0.22.1",
+				"@oxlint-tsgolint/linux-x64": "0.22.1",
+				"@oxlint-tsgolint/win32-arm64": "0.22.1",
+				"@oxlint-tsgolint/win32-x64": "0.22.1"
 			}
 		},
 		"node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
 	},
 	"peerDependencies": {
 		"eslint": "^9.7",
-		"oxlint": "^1.57.0",
-		"oxlint-tsgolint": "^0.17.3"
+		"oxlint": "^1.63.0",
+		"oxlint-tsgolint": "^0.22.1"
 	},
 	"dependencies": {
 		"@eslint/js": "^9.39.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@batterii/eslint-config-vurvey",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "Base ESLint configuration for Vurvey TypeScript projects",
 	"author": "Batterii, LLC",
 	"license": "MIT",


### PR DESCRIPTION
The duplicate export rule is confusing, since if fires on `export {someMethod, someConst} from './some-file'` which at least visually, does not have duplicates. 

While I want to minimize barrel files, there are still some cases for the above. This PR also updates the oxlint peer dependencies.